### PR TITLE
ci: k8s version bump 1.2x -> 1.24

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -62,7 +62,7 @@ jobs:
     - uses: balchua/microk8s-actions@v0.2.2
       with:
         addons: '["dns", "storage", "rbac"]'
-        channel: 1.21/stable
+        channel: 1.24/stable
 
       # Avoid race condition with storage taking a long time to initialize
     - name: Wait for storage


### PR DESCRIPTION
[skip ci] ci: k8s version bump 1.2x -> 1.24