### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,8 +14,20 @@ resources:
 provides:
   grpc-web:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
   metrics-endpoint:
     interface: prometheus_scrape
   grafana-dashboards:
@@ -23,5 +35,17 @@ provides:
 requires:
   grpc:
     interface: grpc
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/grpc.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: string
+          required:
+          - service
+          - port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/grpc.yaml


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).