### PR TITLE
feat: Introduce ingress relation

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,7 @@ jobs:
         provider: microk8s
         channel: 1.25-strict/stable
         juju-channel: 3.1/stable
-        microk8s-addons: "dns hostpath-storage rbac"
+        microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
 
     - name: Test
       run: sg snap_microk8s -c "tox -vve integration -- --model testing"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -86,6 +86,14 @@ jobs:
       run: kubectl logs --tail 100 -ntesting -ljuju-operator=mlmd
       if: failure()
 
+    - name: Get istio-pilot workload logs
+      run: kubectl logs --tail 100 -ntesting -ljuju-app=istio-pilot
+      if: failure()
+
+    - name: Get istio-pilot operator logs
+      run: kubectl logs --tail 100 -ntesting -ljuju-operator=istio-pilot
+      if: failure()
+
     - name: Collect charm debug artifacts
       uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
       if: always()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -71,19 +71,19 @@ jobs:
       if: failure()
 
     - name: Get envoy workload logs
-      run: kubectl logs --tail 100 -nci-test -ljuju-app=envoy
+      run: kubectl logs --tail 100 -ntesting -ljuju-app=envoy
       if: failure()
 
     - name: Get envoy operator logs
-      run: kubectl logs --tail 100 -nci-test -ljuju-operator=envoy
+      run: kubectl logs --tail 100 -ntesting -ljuju-operator=envoy
       if: failure()
 
     - name: Get mlmd workload logs
-      run: kubectl logs --tail 100 -nci-test -ljuju-app=mlmd
+      run: kubectl logs --tail 100 -ntesting -ljuju-app=mlmd
       if: failure()
 
     - name: Get mlmd operator logs
-      run: kubectl logs --tail 100 -nci-test -ljuju-operator=mlmd
+      run: kubectl logs --tail 100 -ntesting -ljuju-operator=mlmd
       if: failure()
 
     - name: Collect charm debug artifacts

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,3 +25,43 @@ requires:
     interface: grpc
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/grpc.yaml
     versions: [v1]
+  ingress:
+    interface: ingress
+    schema:
+      v2:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            namespace:
+              type: string
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - namespace
+          - prefix
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - prefix
+    versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -4,4 +4,5 @@ selenium
 selenium-wire
 lightkube
 aiohttp
+tenacity
 -r requirements.txt

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -2,4 +2,6 @@ juju
 pytest-operator
 selenium
 selenium-wire
+lightkube
+aiohttp
 -r requirements.txt

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -295,6 +295,8 @@ stack-data==0.6.3
     # via ipython
 stringcase==1.2.0
     # via -r requirements.txt
+tenacity==8.2.3
+    # via -r requirements-integration.in
 tomli==2.0.1
     # via
     #   ipdb

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,11 +4,20 @@
 #
 #    pip-compile requirements-integration.in
 #
+aiohttp==3.8.6
+    # via -r requirements-integration.in
+aiosignal==1.3.1
+    # via aiohttp
+anyio==4.0.0
+    # via httpcore
 asttokens==2.4.0
     # via stack-data
+async-timeout==4.0.3
+    # via aiohttp
 attrs==23.1.0
     # via
     #   -r requirements.txt
+    #   aiohttp
     #   jsonschema
     #   outcome
     #   trio
@@ -29,6 +38,8 @@ cachetools==5.3.1
 certifi==2023.7.22
     # via
     #   -r requirements.txt
+    #   httpcore
+    #   httpx
     #   kubernetes
     #   requests
     #   selenium
@@ -40,6 +51,7 @@ cffi==1.16.0
 charset-normalizer==3.3.0
     # via
     #   -r requirements.txt
+    #   aiohttp
     #   requests
 cryptography==41.0.4
     # via
@@ -53,11 +65,16 @@ envoy-data-plane==0.2.5
     # via -r requirements.txt
 exceptiongroup==1.1.3
     # via
+    #   anyio
     #   pytest
     #   trio
     #   trio-websocket
 executing==2.0.0
     # via stack-data
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
 google-auth==2.23.3
     # via kubernetes
 grpclib==0.4.6
@@ -65,7 +82,9 @@ grpclib==0.4.6
     #   -r requirements.txt
     #   betterproto
 h11==0.14.0
-    # via wsproto
+    # via
+    #   httpcore
+    #   wsproto
 h2==4.1.0
     # via
     #   -r requirements.txt
@@ -75,6 +94,10 @@ hpack==4.0.0
     # via
     #   -r requirements.txt
     #   h2
+httpcore==0.18.0
+    # via httpx
+httpx==0.25.0
+    # via lightkube
 hvac==1.2.1
     # via juju
 hyperframe==6.0.1
@@ -85,8 +108,11 @@ hyperframe==6.0.1
 idna==3.4
     # via
     #   -r requirements.txt
+    #   anyio
+    #   httpx
     #   requests
     #   trio
+    #   yarl
 importlib-resources==6.1.0
     # via
     #   -r requirements.txt
@@ -113,6 +139,10 @@ kaitaistruct==0.10
     # via selenium-wire
 kubernetes==27.2.0
     # via juju
+lightkube==0.14.0
+    # via -r requirements-integration.in
+lightkube-models==1.28.1.4
+    # via lightkube
 macaroonbakery==1.3.1
     # via juju
 markupsafe==2.1.3
@@ -122,7 +152,9 @@ matplotlib-inline==0.1.6
 multidict==6.0.4
     # via
     #   -r requirements.txt
+    #   aiohttp
     #   grpclib
+    #   yarl
 mypy-extensions==1.0.0
     # via typing-inspect
 oauthlib==3.2.2
@@ -218,6 +250,7 @@ pyyaml==6.0.1
     #   -r requirements.txt
     #   juju
     #   kubernetes
+    #   lightkube
     #   ops
     #   pytest-operator
     #   serialized-data-interface
@@ -251,7 +284,11 @@ six==1.16.0
     #   pymacaroons
     #   python-dateutil
 sniffio==1.3.0
-    # via trio
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
+    #   trio
 sortedcontainers==2.4.0
     # via trio
 stack-data==0.6.3
@@ -299,6 +336,8 @@ wsproto==1.2.0
     # via
     #   selenium-wire
     #   trio-websocket
+yarl==1.9.2
+    # via aiohttp
 zipp==3.17.0
     # via
     #   -r requirements.txt

--- a/src/charm.py
+++ b/src/charm.py
@@ -168,7 +168,7 @@ class Operator(CharmBase):
 
             self._send_info(interfaces)
 
-            self._configure_mesh(interfaces)
+            self._send_data_to_ingress_provider(interfaces)
 
         except CheckFailed as check_failed:
             self.model.unit.status = check_failed.status
@@ -280,7 +280,10 @@ class Operator(CharmBase):
             raise CheckFailed("Waiting for upstream gRPC connection information.", WaitingStatus)
         return upstreams
 
-    def _configure_mesh(self, interfaces):
+    def _send_data_to_ingress_provider(self, interfaces):
+        """Send data to the ingress relation data bag so the VirtualServices provider configures
+        a VirtualService routing traffic from `/ml_metadata` path to envoy service.
+        """
         if interfaces["ingress"]:
             interfaces["ingress"].send_data(
                 {

--- a/src/charm.py
+++ b/src/charm.py
@@ -283,6 +283,8 @@ class Operator(CharmBase):
     def _send_data_to_ingress_provider(self, interfaces):
         """Send data to the ingress relation data bag so the VirtualServices provider configures
         a VirtualService routing traffic from `/ml_metadata` path to envoy service.
+
+        Raises an exception and sets the charm to Blocked if there is no ingress relation available
         """
         if interfaces["ingress"]:
             interfaces["ingress"].send_data(
@@ -292,6 +294,11 @@ class Operator(CharmBase):
                     "service": self.model.app.name,
                     "port": int(self.model.config["http-port"]),
                 }
+            )
+        else:
+            raise CheckFailed(
+                "No 'ingress' relation available, please relate to a VirtualServices provider e.g. istio-pilot.",  # noqa E501
+                BlockedStatus,
             )
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -297,7 +297,7 @@ class Operator(CharmBase):
             )
         else:
             raise CheckFailed(
-                "No 'ingress' relation available, please relate to a VirtualServices provider e.g. istio-pilot.",  # noqa E501
+                "Please relate to istio-pilot, no ingress relation available.",
                 BlockedStatus,
             )
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -42,7 +42,12 @@ async def test_build_and_deploy(ops_test):
     resources = {"oci-image": image_path}
     await ops_test.model.deploy(charm, resources=resources)
     await ops_test.model.add_relation(APP_NAME, MLMD)
-    await ops_test.model.wait_for_idle(status="active", raise_on_blocked=True, idle_period=30)
+    await ops_test.model.wait_for_idle(
+        apps=[MLMD], status="active", raise_on_blocked=False, idle_period=30
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="blocked", raise_on_blocked=False, idle_period=30
+    )
 
     relation = ops_test.model.relations[0]
     assert [app.entity_id for app in relation.applications] == [APP_NAME, MLMD]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -60,19 +60,20 @@ async def test_virtual_service(ops_test, lightkube_client):
 
     await ops_test.model.deploy(
         "istio-gateway",
-        application_name="istio-ingressgateway",
+        application_name=ISTIO_GW,
         channel="latest/edge",
         config={"kind": "ingress"},
         trust=True,
     )
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:{ISTIO_PILOT}", f"{ISTIO_GW}:{ISTIO_PILOT}")
-    await ops_test.model.add_relation(ISTIO_PILOT, APP_NAME)
 
     await ops_test.model.wait_for_idle(
         raise_on_blocked=False,
         raise_on_error=True,
         timeout=300,
     )
+
+    await ops_test.model.add_relation(ISTIO_PILOT, APP_NAME)
 
     # Verify that virtualService is as expected
     assert_virtualservice_exists(name=APP_NAME, namespace=ops_test.model.name)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,9 +5,13 @@ import json
 import logging
 from pathlib import Path
 
+import aiohttp
 import pytest
 import requests
 import yaml
+from lightkube import Client
+from lightkube.generic_resource import create_namespaced_resource
+from lightkube.resources.core_v1 import Service
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +24,14 @@ PROMETHEUS = "prometheus-k8s"
 GRAFANA = "grafana-k8s"
 PROMETHEUS_SCRAPE = "prometheus-scrape-config-k8s"
 MLMD = "mlmd"
+ISTIO_PILOT = "istio-pilot"
+ISTIO_GW = "istio-ingressgateway"
+
+
+@pytest.fixture(scope="session")
+def lightkube_client() -> Client:
+    client = Client(field_manager=APP_NAME)
+    return client
 
 
 @pytest.mark.abort_on_fail
@@ -35,6 +47,40 @@ async def test_build_and_deploy(ops_test):
     relation = ops_test.model.relations[0]
     assert [app.entity_id for app in relation.applications] == [APP_NAME, MLMD]
     assert all([endpoint.name == "grpc" for endpoint in relation.endpoints])
+
+
+@pytest.mark.abort_on_fail
+async def test_virtual_service(ops_test, lightkube_client):
+    await ops_test.model.deploy(
+        ISTIO_PILOT,
+        channel="latest/edge",
+        config={"default-gateway": "kubeflow-gateway"},
+        trust=True,
+    )
+
+    await ops_test.model.deploy(
+        "istio-gateway",
+        application_name="istio-ingressgateway",
+        channel="latest/edge",
+        config={"kind": "ingress"},
+        trust=True,
+    )
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:{ISTIO_PILOT}", f"{ISTIO_GW}:{ISTIO_PILOT}")
+    await ops_test.model.add_relation(ISTIO_PILOT, APP_NAME)
+
+    await ops_test.model.wait_for_idle(
+        raise_on_blocked=False,
+        raise_on_error=True,
+        timeout=300,
+    )
+
+    # Verify that virtualService is as expected
+    assert_virtualservice_exists(name=APP_NAME, namespace=ops_test.model.name)
+
+    # Verify `/ml_metadata` endpoint is served
+    regular_ingress_gateway_ip = await get_gateway_ip(namespace=ops_test.model.name)
+    res_status, res_text = await fetch_response(f"http://{regular_ingress_gateway_ip}/ml_metadata")
+    assert res_status != 404
 
 
 @pytest.mark.abort_on_fail
@@ -74,3 +120,39 @@ async def test_correct_observability_setup(ops_test):
     assert response_metric["juju_charm"] == APP_NAME
     assert response_metric["juju_model"] == ops_test.model_name
     assert response_metric["juju_unit"] == f"{APP_NAME}/0"
+
+
+def assert_virtualservice_exists(name: str, namespace: str):
+    """Will raise a ApiError(404) if the virtualservice does not exist."""
+    log.info(f"Asserting that  VirtualService '{name}' exists.")
+    lightkube_client = Client()
+    virtual_service_lightkube_resource = create_namespaced_resource(
+        group="networking.istio.io",
+        version="v1alpha3",
+        kind="VirtualService",
+        plural="virtualservices",
+    )
+    lightkube_client.get(virtual_service_lightkube_resource, name, namespace=namespace)
+    log.info(f"VirtualService '{name}' exists.")
+
+
+async def fetch_response(url, headers=None):
+    """Fetch provided URL and return pair - status and text (int, string)."""
+    result_status = 0
+    result_text = ""
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=headers) as response:
+            result_status = response.status
+            result_text = await response.text()
+    return result_status, str(result_text)
+
+
+async def get_gateway_ip(
+    namespace: str,
+    service_name: str = "istio-ingressgateway-workload",
+):
+    log.info(f"Getting {service_name} ingress ip")
+    lightkube_client = Client()
+    service = lightkube_client.get(Service, service_name, namespace=namespace)
+    gateway_ip = service.status.loadBalancer.ingress[0].ip
+    return gateway_ip

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -66,14 +66,14 @@ async def test_virtual_service(ops_test, lightkube_client):
         trust=True,
     )
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:{ISTIO_PILOT}", f"{ISTIO_GW}:{ISTIO_PILOT}")
+    await ops_test.model.add_relation(ISTIO_PILOT, APP_NAME)
 
     await ops_test.model.wait_for_idle(
+        status="active",
         raise_on_blocked=False,
         raise_on_error=True,
         timeout=300,
     )
-
-    await ops_test.model.add_relation(ISTIO_PILOT, APP_NAME)
 
     # Verify that virtualService is as expected
     assert_virtualservice_exists(name=APP_NAME, namespace=ops_test.model.name)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -54,6 +54,20 @@ def test_many_relations(harness):
     assert harness.charm.model.unit.status == ActiveStatus("")
 
 
+def test_with_ingress_relation(harness):
+    harness.set_leader(True)
+    add_oci_image(harness)
+
+    # Set required grpc relation
+    setup_grpc_relation(harness, "grpc-one", "8080")
+
+    setup_ingress_relation(harness)
+
+    harness.begin_with_initial_hooks()
+
+    assert isinstance(harness.charm.model.unit.status, ActiveStatus)
+
+
 # Helper functions
 def add_oci_image(harness: Harness):
     harness.add_oci_resource(
@@ -64,6 +78,17 @@ def add_oci_image(harness: Harness):
             "password": "",
         },
     )
+
+
+def setup_ingress_relation(harness: Harness):
+    rel_id = harness.add_relation("ingress", "istio-pilot")
+    harness.add_relation_unit(rel_id, "istio-pilot/0")
+    harness.update_relation_data(
+        rel_id,
+        "istio-pilot",
+        {"_supported_versions": "- v1"},
+    )
+    return rel_id
 
 
 def setup_grpc_relation(harness: Harness, name: str, port: str):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -42,6 +42,8 @@ def test_many_relations(harness):
 
     setup_grpc_relation(harness, "grpc-one", "8080")
     setup_grpc_relation(harness, "grpc-two", "9090")
+    # In order to avoid the charm going to Blocked
+    setup_ingress_relation(harness)
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()


### PR DESCRIPTION
- Introduce ingress relation so that a virtualService can be created pointing to the envoy's service and UI components can access it using the [gRPC-Web](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_web_filter) protocol.
- Add ingress relation unit and integration test

Fixes #61 