### PR TITLE
fix: Update envoy configuration

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: envoyproxy/envoy:v1.12.2
+    upstream-source: gcr.io/ml-pipeline/metadata-envoy:2.0.2
 provides:
   grpc-web:
     interface: k8s-service

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,7 +26,7 @@ def get_cluster(service: str, port: int):
         name=service,
         connect_timeout=timedelta(seconds=30),
         type=api.ClusterDiscoveryType.LOGICAL_DNS,
-        http2_protocol_options=api.core.Http2ProtocolOptions(),
+        http2_protocol_options=api.core.Http2ProtocolOptions(stream_error_on_invalid_http_messaging=False),
         lb_policy=api.ClusterLbPolicy.ROUND_ROBIN,
         hosts=[
             api.core.Address(
@@ -70,7 +70,7 @@ def get_listener(cluster: str, port: int):
                 match=api.route.RouteMatch(prefix="/"),
                 route=api.route.RouteAction(
                     cluster=cluster,
-                    max_grpc_timeout=timedelta(seconds=0),
+                    max_grpc_timeout=timedelta(seconds=60),
                 ),
             )
         ],
@@ -100,7 +100,7 @@ def get_listener(cluster: str, port: int):
         ),
     )
     return api.Listener(
-        name="listener-0",
+        name="listener_0",
         address=api.core.Address(
             socket_address=api.core.SocketAddress(
                 address="0.0.0.0",

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,7 +26,9 @@ def get_cluster(service: str, port: int):
         name=service,
         connect_timeout=timedelta(seconds=30),
         type=api.ClusterDiscoveryType.LOGICAL_DNS,
-        http2_protocol_options=api.core.Http2ProtocolOptions(stream_error_on_invalid_http_messaging=False),
+        http2_protocol_options=api.core.Http2ProtocolOptions(
+            stream_error_on_invalid_http_messaging=False
+        ),
         lb_policy=api.ClusterLbPolicy.ROUND_ROBIN,
         hosts=[
             api.core.Address(

--- a/tests/unit/many_relations.yaml
+++ b/tests/unit/many_relations.yaml
@@ -14,6 +14,7 @@ static_resources:
     - socket_address:
         address: grpc-one
         port_value: 8080
+    http2_protocol_options: {}
     name: grpc-one
     type: LOGICAL_DNS
   - connect_timeout: 30.000s
@@ -21,6 +22,7 @@ static_resources:
     - socket_address:
         address: grpc-two
         port_value: 9090
+    http2_protocol_options: {}
     name: grpc-two
     type: LOGICAL_DNS
   listeners:
@@ -53,9 +55,10 @@ static_resources:
                   prefix: /
                 route:
                   cluster: grpc-one
+                  max_grpc_timeout: '60.000s'
           stat_prefix: ingress_http
         name: envoy.http_connection_manager
-    name: listener-0
+    name: listener_0
   - address:
       socket_address:
         address: 0.0.0.0
@@ -85,6 +88,7 @@ static_resources:
                   prefix: /
                 route:
                   cluster: grpc-two
+                  max_grpc_timeout: '60.000s'
           stat_prefix: ingress_http
         name: envoy.http_connection_manager
-    name: listener-0
+    name: listener_0


### PR DESCRIPTION
Details in #63.

- Update envoy configuration to:
  - include empty value for [static.resources.http2_protocol_options](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/upstreams/http/v3/http_protocol_options.proto#extensions-upstreams-http-v3-httpprotocoloptions-explicithttpconfig) field since this must be set.
  - revert [max_grpc_timeout](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#envoy-v3-api-field-config-route-v3-routeaction-max-grpc-timeout) to 60 (a large enough timeout). Setting it to 0 resulted in the SDK not 
rendering it. When this value is empty, envoy uses [timeout](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#envoy-v3-api-field-config-route-v3-routeaction-timeout)'s default value which is 15s, while 
upstream has set this to 0, meaning that there is no timeout.
  - Rename listener to `listener_0` in order to not diverge from upstream without a reason.
- Update to use the image built from this [Dockerfile](https://github.com/kubeflow/pipelines/blob/master/third_party/metadata_envoy/Dockerfile#L26) in order to not diverge from upstream without a 
reason. Since we define the command ourselves in the charm, the different `cmd` shouldn't bite us. 

Fixes #63