### PR TITLE
fix: Rename relation to `grafana-dashboard`

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ provides:
     versions: [v1]
   metrics-endpoint:
     interface: prometheus_scrape
-  grafana-dashboards:
+  grafana-dashboard:
     interface: grafana_dashboard
 requires:
   grpc:

--- a/src/charm.py
+++ b/src/charm.py
@@ -144,7 +144,7 @@ class Operator(CharmBase):
 
         self.dashboard_provider = GrafanaDashboardProvider(
             self,
-            relation_name="grafana-dashboards",
+            relation_name="grafana-dashboard",
         )
 
         for event in [


### PR DESCRIPTION
* Rename relation from `grafana-dashboards` to `grafana-dashboard` in order to:
  * follow what every other CKF charm does (examples: [minio](https://github.com/canonical/minio-operator/blob/061c09d70d7474b349cf8e2df9642eab780c4729/metadata.yaml#L50), [seldon](https://github.com/canonical/seldon-core-operator/blob/d58d13249f6aa9e5e651df7754ba3258c6603cc5/metadata.yaml#L32))
  * not diverge from the [grafana library default](https://github.com/canonical/envoy-operator/blob/338f000c2c2e879be478ccbcbf555242542b5874/lib/charms/grafana_k8s/v0/grafana_dashboard.py#L51).

Part of canonical/bundle-kubeflow#856
Refs canonical/bundle-kubeflow#834