### PR TITLE
backport(fix): Rename relation to `grafana-dashboard` from #79

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ provides:
     versions: [v1]
   metrics-endpoint:
     interface: prometheus_scrape
-  grafana-dashboards:
+  grafana-dashboard:
     interface: grafana_dashboard
 requires:
   grpc:

--- a/src/charm.py
+++ b/src/charm.py
@@ -144,7 +144,7 @@ class Operator(CharmBase):
 
         self.dashboard_provider = GrafanaDashboardProvider(
             self,
-            relation_name="grafana-dashboards",
+            relation_name="grafana-dashboard",
         )
 
         for event in [


### PR DESCRIPTION
Backport the following:
* Rename relation from `grafana-dashboards` to `grafana-dashboard` in order to:
  * follow what every other CKF charm does.
  * not diverge from the grafana library default.

Part of canonical/bundle-kubeflow#856
Refs canonical/bundle-kubeflow#834