### PR TITLE
fix: define relations schema in metadata.yaml to enable airgapped

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,8 +14,20 @@ resources:
 provides:
   grpc-web:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+            - service-name
+            - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
   metrics-endpoint:
     interface: prometheus_scrape
   grafana-dashboard:
@@ -23,8 +35,20 @@ provides:
 requires:
   grpc:
     interface: grpc
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/grpc.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: string
+          required:
+            - service
+            - port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/grpc.yaml
   ingress:
     interface: ingress
     schema:


### PR DESCRIPTION
closes #98 

## Summary
Adds the definition for the schemas of:
* `grpc` relation
* `grpc-web` relation

to the metadata.yaml instead of used a remote link to enable deploying `envoy` in airgapped environments.