### PR TITLE
fix: Add livenessProbe to workload pod

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -236,6 +236,21 @@ class Operator(CharmBase):
                                 ],
                             }
                         ],
+                        "kubernetes": {
+                            "livenessProbe": {
+                                "initialDelaySeconds": 15,
+                                "httpGet": {
+                                    "path": "/",
+                                    "port": 9090,
+                                    "httpHeaders": [
+                                        {
+                                            "name": "Content-Type",
+                                            "value": "application/grpc-web-text",
+                                        }
+                                    ],
+                                },
+                            }
+                        },
                     }
                 ],
             },


### PR DESCRIPTION
Adds the condition from integration tests as a `livenessProbe` to the workload container in order to ensure that the workload container restarts if it's not functional.

Closes canonical/bundle-kubeflow#966