### PR TITLE
chore: update python dependencies + pin pip

### DIFF
--- a/requirements-fmt.txt
+++ b/requirements-fmt.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==24.3.0
+black==24.8.0
     # via -r requirements-fmt.in
 click==8.1.7
     # via black
@@ -12,13 +12,13 @@ isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==24.0
+packaging==24.2
     # via black
 pathspec==0.12.1
     # via black
-platformdirs==4.2.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via black

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,25 +4,19 @@
 #
 #    pip-compile requirements-integration.in
 #
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.4
+    # via aiohttp
+aiohttp==3.10.11
     # via -r requirements-integration.in
 aiosignal==1.3.1
     # via aiohttp
-annotated-types==0.6.0
-    # via
-    #   -r requirements.txt
-    #   pydantic
-anyio==4.3.0
-    # via
-    #   -r requirements.txt
-    #   httpx
-appnope==0.1.4
-    # via ipython
-asttokens==2.4.1
+anyio==4.5.2
+    # via httpx
+asttokens==3.0.0
     # via stack-data
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
@@ -30,15 +24,17 @@ attrs==23.2.0
     #   trio
 backcall==0.2.0
     # via ipython
-bcrypt==4.1.3
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
 blinker==1.8.2
     # via selenium-wire
 brotli==1.1.0
     # via selenium-wire
-cachetools==5.3.3
+cachetools==5.5.0
     # via google-auth
-certifi==2024.6.2
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
@@ -46,15 +42,15 @@ certifi==2024.6.2
     #   requests
     #   selenium
     #   selenium-wire
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.1
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements-integration.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cryptography==42.0.8
+cryptography==44.0.0
     # via
     #   paramiko
     #   pyopenssl
@@ -64,19 +60,19 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
     #   trio
     #   trio-websocket
-executing==2.0.1
+executing==2.1.0
     # via stack-data
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.30.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via
@@ -86,24 +82,24 @@ h2==4.1.0
     # via selenium-wire
 hpack==4.0.0
     # via h2
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via lightkube
-hvac==2.2.0
+hvac==2.3.0
     # via juju
 hyperframe==6.0.1
     # via
     #   h2
     #   selenium-wire
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
     #   trio
     #   yarl
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -111,7 +107,7 @@ ipdb==0.13.13
     # via pytest-operator
 ipython==8.12.3
     # via ipdb
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via
@@ -119,7 +115,7 @@ jinja2==3.1.4
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.5.0.0
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
@@ -128,11 +124,11 @@ kaitaistruct==0.10
     # via selenium-wire
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.3
+lightkube==0.15.5
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.30.0.8
+lightkube-models==1.31.1.8
     # via lightkube
 macaroonbakery==1.3.4
     # via juju
@@ -140,7 +136,7 @@ markupsafe==2.1.5
     # via jinja2
 matplotlib-inline==0.1.7
     # via ipython
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
@@ -150,9 +146,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-oci-image==1.0.0
-    # via -r requirements.txt
-ops==2.14.0
+ops==2.17.1
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
@@ -160,11 +154,11 @@ ordered-set==4.1.0
     # via deepdiff
 outcome==1.3.0.post0
     # via trio
-packaging==24.1
+packaging==24.2
     # via
     #   juju
     #   pytest
-paramiko==3.4.0
+paramiko==3.5.0
     # via juju
 parso==0.8.4
     # via jedi
@@ -176,21 +170,23 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==5.27.1
+propcache==0.2.0
+    # via yarl
+protobuf==5.29.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
     #   selenium-wire
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
@@ -203,9 +199,9 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyopenssl==24.1.0
+pyopenssl==24.3.0
     # via selenium-wire
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via selenium-wire
 pyrfc3339==1.1
     # via
@@ -217,19 +213,19 @@ pysocks==1.7.1
     # via
     #   selenium-wire
     #   urllib3
-pytest==8.2.2
+pytest==8.3.4
     # via
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.35.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   juju
     #   kubernetes
@@ -252,7 +248,7 @@ ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-selenium==4.21.0
+selenium==4.27.1
     # via
     #   -r requirements-integration.in
     #   selenium-wire
@@ -262,7 +258,6 @@ serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
 six==1.16.0
     # via
-    #   asttokens
     #   kubernetes
     #   macaroonbakery
     #   pymacaroons
@@ -270,17 +265,16 @@ six==1.16.0
 sniffio==1.3.1
     # via
     #   anyio
-    #   httpx
     #   trio
 sortedcontainers==2.4.0
     # via trio
 stack-data==0.6.3
     # via ipython
-tenacity==8.4.1
+tenacity==9.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
@@ -290,7 +284,7 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-trio==0.25.1
+trio==0.27.0
     # via
     #   selenium
     #   trio-websocket
@@ -300,11 +294,13 @@ typing-extensions==4.12.2
     # via
     #   anyio
     #   ipython
+    #   juju
+    #   multidict
     #   selenium
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3[socks]==2.2.2
+urllib3[socks]==2.2.3
     # via
     #   kubernetes
     #   requests
@@ -315,15 +311,16 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==12.0
+    #   selenium
+websockets==13.1
     # via juju
 wsproto==1.2.0
     # via
     #   selenium-wire
     #   trio-websocket
-yarl==1.9.4
+yarl==1.15.2
     # via aiohttp
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources
-zstandard==0.22.0
+zstandard==0.23.0
     # via selenium-wire

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==24.3.0
+black==24.8.0
     # via -r requirements-fmt.txt
 click==8.1.7
     # via
     #   -r requirements-fmt.txt
     #   black
-codespell==2.2.6
+codespell==2.3.0
     # via -r requirements-lint.in
 flake8==5.0.4
     # via
@@ -18,7 +18,7 @@ flake8==5.0.4
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.2.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
@@ -30,7 +30,7 @@ mypy-extensions==1.0.0
     # via
     #   -r requirements-fmt.txt
     #   black
-packaging==24.0
+packaging==24.2
     # via
     #   -r requirements-fmt.txt
     #   black
@@ -38,9 +38,9 @@ pathspec==0.12.1
     # via
     #   -r requirements-fmt.txt
     #   black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==4.2.0
+platformdirs==4.3.6
     # via
     #   -r requirements-fmt.txt
     #   black
@@ -50,12 +50,12 @@ pyflakes==2.5.0
     # via flake8
 pyproject-flake8==5.0.4.post1
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   -r requirements-fmt.txt
     #   black
     #   pyproject-flake8
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via
     #   -r requirements-fmt.txt
     #   black

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -4,62 +4,92 @@
 #
 #    pip-compile requirements-unit.in
 #
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via
     #   -r requirements.txt
     #   pydantic
-anyio==4.3.0
+anyio==4.5.2
     # via
     #   -r requirements.txt
     #   httpx
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -r requirements.txt
     #   jsonschema
-certifi==2024.2.2
+backports-strenum==1.3.1
+    # via
+    #   -r requirements.txt
+    #   juju
+bcrypt==4.2.1
+    # via
+    #   -r requirements.txt
+    #   paramiko
+cachetools==5.5.0
+    # via
+    #   -r requirements.txt
+    #   google-auth
+certifi==2024.8.30
     # via
     #   -r requirements.txt
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.3.0
+cffi==1.17.1
+    # via
+    #   -r requirements.txt
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.txt
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -r requirements.txt
     #   requests
-cosl==0.0.12
+cosl==0.0.45
     # via -r requirements.txt
-coverage==7.4.4
+coverage==7.6.1
     # via -r requirements-unit.in
+cryptography==44.0.0
+    # via
+    #   -r requirements.txt
+    #   paramiko
 deepdiff==6.2.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via
     #   -r requirements.txt
     #   anyio
     #   pytest
+google-auth==2.36.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
 h11==0.14.0
     # via
     #   -r requirements.txt
     #   httpcore
-httpcore==1.0.4
+httpcore==1.0.7
     # via
     #   -r requirements.txt
     #   httpx
-httpx==0.27.0
+httpx==0.28.0
     # via
     #   -r requirements.txt
     #   lightkube
-idna==3.6
+hvac==2.3.0
+    # via
+    #   -r requirements.txt
+    #   juju
+idna==3.10
     # via
     #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.3.2
+importlib-resources==6.4.5
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -73,21 +103,43 @@ jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-lightkube==0.15.2
+juju==3.6.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-lightkube-models==1.29.0.7
+kubernetes==30.1.0
+    # via
+    #   -r requirements.txt
+    #   juju
+lightkube==0.15.5
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
+    #   cosl
+lightkube-models==1.31.1.8
     # via
     #   -r requirements.txt
     #   lightkube
+macaroonbakery==1.3.4
+    # via
+    #   -r requirements.txt
+    #   juju
 markupsafe==2.1.5
     # via
     #   -r requirements.txt
     #   jinja2
+mypy-extensions==1.0.0
+    # via
+    #   -r requirements.txt
+    #   typing-inspect
+oauthlib==3.2.2
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   requests-oauthlib
 oci-image==1.0.0
     # via -r requirements.txt
-ops==2.14.0
+ops==2.17.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -97,44 +149,108 @@ ordered-set==4.1.0
     # via
     #   -r requirements.txt
     #   deepdiff
-packaging==24.0
-    # via pytest
+packaging==24.2
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pytest
+paramiko==3.5.0
+    # via
+    #   -r requirements.txt
+    #   juju
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements.txt
     #   jsonschema
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
+protobuf==5.29.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via
+    #   -r requirements.txt
+    #   google-auth
+pycparser==2.22
+    # via
+    #   -r requirements.txt
+    #   cffi
 pydantic==2.6.4
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   cosl
 pydantic-core==2.16.3
     # via
     #   -r requirements.txt
     #   pydantic
+pymacaroons==0.13.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pynacl==1.5.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via
     #   -r requirements.txt
     #   jsonschema
-pytest==8.1.1
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-lazy-fixture
     #   pytest-mock
 pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via -r requirements-unit.in
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+pytz==2024.2
+    # via
+    #   -r requirements.txt
+    #   pyrfc3339
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements.txt
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
     #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+rsa==4.9
+    # via
+    #   -r requirements.txt
+    #   google-auth
 ruamel-yaml==0.18.6
     # via
     #   -r requirements.txt
@@ -147,34 +263,57 @@ serialized-data-interface==0.7.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
+six==1.16.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
 sniffio==1.3.1
     # via
     #   -r requirements.txt
     #   anyio
-    #   httpx
-tenacity==8.2.3
+tenacity==9.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+    #   cosl
+tomli==2.2.1
     # via pytest
-typing-extensions==4.10.0
+toposort==1.10
+    # via
+    #   -r requirements.txt
+    #   juju
+typing-extensions==4.12.2
     # via
     #   -r requirements.txt
     #   annotated-types
     #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
-urllib3==2.2.1
+    #   typing-inspect
+typing-inspect==0.9.0
     # via
     #   -r requirements.txt
+    #   juju
+urllib3==2.2.3
+    # via
+    #   -r requirements.txt
+    #   kubernetes
     #   requests
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via
     #   -r requirements.txt
+    #   kubernetes
     #   ops
-zipp==3.18.1
+websockets==13.1
+    # via
+    #   -r requirements.txt
+    #   juju
+zipp==3.20.2
     # via
     #   -r requirements.txt
     #   importlib-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,53 +4,84 @@
 #
 #    pip-compile requirements.in
 #
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-certifi==2024.2.2
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.3.0
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.12
+cosl==0.0.45
     # via -r requirements.in
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.4
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via lightkube
-idna==3.6
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.3.2
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.2
+juju==3.6.0.0
     # via charmed-kubeflow-chisme
-lightkube-models==1.29.0.7
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
+    # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+lightkube-models==1.31.1.8
     # via lightkube
+macaroonbakery==1.3.4
+    # via juju
 markupsafe==2.1.5
     # via jinja2
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
 oci-image==1.0.0
     # via -r requirements.in
-ops==2.14.0
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -58,44 +89,105 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.2
+    # via juju
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
 pydantic==2.6.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   cosl
 pydantic-core==2.16.3
     # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
+pyyaml==6.0.2
     # via
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
 ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.1
+six==1.16.0
     # via
-    #   anyio
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-typing-extensions==4.10.0
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
     # via
     #   annotated-types
     #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
-urllib3==2.2.1
-    # via requests
-websocket-client==1.7.0
-    # via ops
-zipp==3.18.1
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]


### PR DESCRIPTION
* Pin pip to 24.2 due to https://github.com/jazzband/pip-tools/issues/2131
* Update python dependencies using 'tox -e update-requirements'

Ref canonical/bundle-kubeflow#1177