### PR TITLE
chore: use canonical envoy rock 1.28.2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: gcr.io/ml-pipeline/metadata-envoy:2.2.0
+    upstream-source: ghcr.io/canonical/envoy:1.28.2
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/src/components/pebble.py
+++ b/src/components/pebble.py
@@ -23,7 +23,7 @@ class EnvoyPebbleService(PebbleServiceComponent):
                         "override": "replace",
                         "summary": "envoy service",
                         "startup": "enabled",
-                        "command": ("/usr/local/bin/envoy" " -c" f" {config_path}"),
+                        "command": ("envoy" " -c" f" {config_path}"),
                     }
                 }
             }


### PR DESCRIPTION
This is not to be merged. It is a PR used for the exploration work of the linked issue. Note that the CI has been rerun because it failed due to cos charms not being active.

Ref canonical/pipelines-rocks#155