### PR TITLE
chore: upgrade to 2.4.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: gcr.io/ml-pipeline/metadata-envoy:2.2.0
+    upstream-source: ghcr.io/kubeflow/kfp-metadata-envoy:2.4.0
 provides:
   metrics-endpoint:
     interface: prometheus_scrape


### PR DESCRIPTION
Upgrade manifests and images to 2.4 according to KFP's manifests. 
See kfp's [CONTRIBUTING.md](https://github.com/canonical/kfp-operators/blob/main/CONTRIBUTING.md) file for instructions.

Close https://warthogs.atlassian.net/browse/KF-6862