### PR TITLE
chore: integrate envoy rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: ghcr.io/kubeflow/kfp-metadata-envoy:2.4.0
+    upstream-source: ghcr.io/canonical/envoy:1.28.2
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/src/components/pebble.py
+++ b/src/components/pebble.py
@@ -23,7 +23,7 @@ class EnvoyPebbleService(PebbleServiceComponent):
                         "override": "replace",
                         "summary": "envoy service",
                         "startup": "enabled",
-                        "command": ("/usr/local/bin/envoy" " -c" f" {config_path}"),
+                        "command": ("envoy" " -c" f" {config_path}"),
                     }
                 }
             }


### PR DESCRIPTION
Closes #149 

* Integrates Canonical envoy rock version `1.28.2` from https://github.com/canonical/envoy-rock
* Adjusts the entrypoint command to work with the rock

## Testing
1. Deploy `latest/edge` bundle on juju 3.6 and microk8s 1.31
2. Refresh the envoy charm and set the image to the rock:
```
juju refresh envoy --channel=latest/edge/pr-150 --base ubuntu@20.04 --resource oci-image=ghcr.io/canonical/envoy:1.28.2
```
3. Run the kfp-v2 [UATs](https://github.com/canonical/charmed-kubeflow-uats?tab=readme-ov-file#run-the-tests) and make sure the pipeline succeeds.

Results:
![image](https://github.com/user-attachments/assets/8d587d42-8a64-4409-a920-6cf992084feb)
UATs passed and pipeline run succeeded