### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -46,7 +46,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -85,7 +85,9 @@ hpack==4.0.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 hyperframe==6.0.1

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -1,0 +1,14 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+MLMD = CharmSpec(charm="mlmd", channel="latest/edge", trust=True)
+ISTIO_GATEWAY = CharmSpec(
+    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+)
+ISTIO_PILOT = CharmSpec(
+    charm="istio-pilot",
+    channel="latest/edge",
+    config={"default-gateway": "kubeflow-gateway"},
+    trust=True,
+)


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
