### PR TITLE
fix: Change dump-charm-debug-artifacts on failure

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -103,4 +103,4 @@ jobs:
 
     - name: Collect charm debug artifacts
       uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-      if: always()
+      if: failure()


### PR DESCRIPTION
https://github.com/canonical/bundle-kubeflow/issues/1341