### PR TITLE
feat: Update manifests to match upstream kfp `2.16.0` release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,9 +6,9 @@ description: https://www.envoyproxy.io/
 containers:
   envoy:
     resource: oci-image
-    # Set these when using the rock
-    # uid: 584792
-    # gid: 584792
+    # Set these to 584792 when using the rock
+    uid: 0
+    gid: 0
 resources:
   oci-image:
     type: oci-image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,8 +6,9 @@ description: https://www.envoyproxy.io/
 containers:
   envoy:
     resource: oci-image
-    uid: 584792
-    gid: 584792
+    # Set these when using the rock
+    # uid: 584792
+    # gid: 584792
 resources:
   oci-image:
     type: oci-image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,8 +7,8 @@ containers:
   envoy:
     resource: oci-image
     # Set these to 584792 when using the rock
-    uid: 1000
-    gid: 1000
+    uid: 0
+    gid: 0
 resources:
   oci-image:
     type: oci-image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: ghcr.io/canonical/envoy:1.28.2-ck8
+    upstream-source: ghcr.io/kubeflow/kfp-metadata-envoy:2.16.0
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,8 +7,8 @@ containers:
   envoy:
     resource: oci-image
     # Set these to 584792 when using the rock
-    uid: 0
-    gid: 0
+    uid: 1000
+    gid: 1000
 resources:
   oci-image:
     type: oci-image


### PR DESCRIPTION
Ref: https://github.com/canonical/kfp-operators/issues/869

This PR updates the charms according to the update to the manifests files corresponding to the `2.16.0` release of Kubeflow pipelines. This task is part of the team's upgrade to Kubeflow `26.03`.

The diff between the 2 version was generated by following the instructions on the [upstream README](https://github.com/kubeflow/manifests?tab=readme-ov-file#pipeline-definitions-stored-as-kubernetes-resources). It can be found [here](https://www.diffchecker.com/NW7YlN8J/).