### PR TITLE
chore: pin charm dependencies in tests (track/2.4)

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -2,13 +2,13 @@
 
 from charmed_kubeflow_chisme.testing import CharmSpec
 
-MLMD = CharmSpec(charm="mlmd", channel="latest/edge", trust=True)
+MLMD = CharmSpec(charm="mlmd", channel="ckf-1.10/edge", trust=True)
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/edge", config={"kind": "ingress"}, trust=True
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="latest/edge",
+    channel="1.28/edge",
     config={"default-gateway": "kubeflow-gateway"},
     trust=True,
 )


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11)
- `mlmd`: `latest/edge` → `ckf-1.10/edge`
- `istio-gateway`: `latest/edge` → `1.28/edge`
- `istio-pilot`: `latest/edge` → `1.28/edge`

Refs: canonical/bundle-kubeflow#1379
